### PR TITLE
feat: 캘린더 0원 표시 숨김 처리

### DIFF
--- a/src/views/CalendarDesk.vue
+++ b/src/views/CalendarDesk.vue
@@ -26,7 +26,7 @@
               <div class="amount-list">
                 <p class="income" v-if="cell.income > 0">+{{ formatAmount(cell.income) }}</p>
                 <p class="expense" v-if="cell.expense > 0">-{{ formatAmount(cell.expense) }}</p>
-                <p class="balance" :class="cell.balance >= 0 ? 'income' : 'expense'">
+                <p v-if="cell.hasData" class="balance" :class="cell.balance >= 0 ? 'income' : 'expense'">
                   {{ cell.balance >= 0 ? '+' : '-' }}{{ formatAmount(Math.abs(cell.balance)) }}
                 </p>
               </div>


### PR DESCRIPTION
작업 내용
- 캘린더 일자 셀에서 거래 데이터가 없을 때 +0 표시 숨김
- 거래 데이터가 있는 날짜에만 금액(수입/지출/총합) 노출

변경 파일
- src/views/CalendarDesk.vue

close #18