### PR TITLE
[#20] feat: 사용자별 거래 데이터 분리

### DIFF
--- a/db.json
+++ b/db.json
@@ -8,7 +8,8 @@
       "category": "급여",
       "amount": 3200000,
       "memo": "4월 급여",
-      "createdAt": 1743465600000
+      "createdAt": 1743465600000,
+      "userId": "G4UtDHpWtds"
     },
     {
       "id": "tr-1002",
@@ -18,7 +19,8 @@
       "category": "식비",
       "amount": 18300,
       "memo": "점심 식사",
-      "createdAt": 1743552000000
+      "createdAt": 1743552000000,
+      "userId": "G4UtDHpWtds"
     },
     {
       "id": "tr-1003",
@@ -28,7 +30,8 @@
       "category": "교통",
       "amount": 56000,
       "memo": "주유비",
-      "createdAt": 1743638400000
+      "createdAt": 1743638400000,
+      "userId": "G4UtDHpWtds"
     },
     {
       "id": "tr-1005",
@@ -38,7 +41,8 @@
       "category": "문화",
       "amount": 45000,
       "memo": "영화 관람",
-      "createdAt": 1743206400000
+      "createdAt": 1743206400000,
+      "userId": "G4UtDHpWtds"
     },
     {
       "id": "tr-1006",
@@ -48,7 +52,8 @@
       "category": "주거",
       "amount": 780000,
       "memo": "관리비 납부",
-      "createdAt": 1742860800000
+      "createdAt": 1742860800000,
+      "userId": "G4UtDHpWtds"
     }
   ],
   "categories": [
@@ -64,7 +69,7 @@
     },
     {
       "id": "cat-income-3",
-      "name": "환급",
+      "name": "상금",
       "type": "income"
     },
     {
@@ -123,6 +128,13 @@
       "password": "abc",
       "createdAt": 1775613374077,
       "id": "G4UtDHpWtds"
+    },
+    {
+      "name": "라마바",
+      "email": "def@def.com",
+      "password": "def",
+      "createdAt": 1775615808748,
+      "id": "r-iTeXqyeA0"
     }
   ],
   "$schema": "./node_modules/json-server/schema.json"

--- a/src/composables/useLedger.js
+++ b/src/composables/useLedger.js
@@ -1,5 +1,6 @@
 import axios from 'axios'
 import { computed, reactive, ref } from 'vue'
+import { useAuth } from './useAuth'
 
 const api = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001',
@@ -7,7 +8,7 @@ const api = axios.create({
 })
 
 const defaultCategories = ['식비', '교통', '주거', '의료', '쇼핑', '문화', '기타']
-const defaultIncomeCategories = ['급여', '부수입', '환급', '용돈', '기타']
+const defaultIncomeCategories = ['급여', '부수입', '상금', '용돈', '기타']
 const defaultAssets = ['현금', '체크카드', '신용카드', '계좌이체']
 
 const pad = (value) => String(value).padStart(2, '0')
@@ -61,9 +62,11 @@ const normalizeTransaction = (item) => ({
   amount: Number(item.amount || 0),
   memo: item.memo || '',
   createdAt: Number(item.createdAt || Date.now()),
+  userId: String(item.userId || ''),
 })
 
 export function useLedger() {
+  const auth = useAuth()
   const today = formatDate(new Date())
 
   const state = reactive({
@@ -82,6 +85,8 @@ export function useLedger() {
   const transactions = ref([])
   const loading = ref(false)
   const statusMessage = ref('데이터를 불러오는 중입니다.')
+
+  const currentUserId = computed(() => auth.state.currentUser?.id || '')
 
   const currentRange = computed(() => {
     if (state.period === 'day') {
@@ -176,13 +181,27 @@ export function useLedger() {
     statusMessage.value = message
   }
 
+  const requireUserId = () => {
+    if (!currentUserId.value) {
+      throw new Error('로그인한 사용자 정보가 없습니다.')
+    }
+
+    return currentUserId.value
+  }
+
   const fetchTransactions = async () => {
     loading.value = true
     try {
-      const response = await api.get('/transactions')
+      const userId = requireUserId()
+      const response = await api.get('/transactions', {
+        params: {
+          userId,
+        },
+      })
       transactions.value = response.data.map(normalizeTransaction)
-      updateStatus(`총 ${transactions.value.length}건 불러왔습니다.`)
+      updateStatus(`총 ${transactions.value.length}건의 내역을 불러왔습니다.`)
     } catch (error) {
+      transactions.value = []
       updateStatus(`조회 실패: ${error.message}`)
     } finally {
       loading.value = false
@@ -191,6 +210,7 @@ export function useLedger() {
   }
 
   const addTransaction = async (payload) => {
+    const userId = requireUserId()
     const request = {
       date: payload.date,
       type: payload.type,
@@ -199,6 +219,7 @@ export function useLedger() {
       amount: Number(payload.amount),
       memo: payload.memo?.trim() || '',
       createdAt: Date.now(),
+      userId,
     }
     const response = await api.post('/transactions', request)
     transactions.value = [normalizeTransaction(response.data), ...transactions.value]
@@ -217,6 +238,7 @@ export function useLedger() {
       category: payload.category,
       amount: Number(payload.amount),
       memo: payload.memo?.trim() || '',
+      userId: target.userId || requireUserId(),
     }
     const response = await api.put(`/transactions/${id}`, request)
     transactions.value = transactions.value.map((item) =>


### PR DESCRIPTION
- 거래 데이터에 사용자 식별값(`userId`) 연결
- 로그인한 사용자 기준으로 거래 내역 조회하도록 수정
- 거래 추가 시 현재 로그인한 사용자 정보와 함께 저장
- 거래 수정/삭제도 현재 사용자 데이터 기준으로 동작하도록 정리
- 기본 샘플 거래 데이터에 사용자 정보 반영
