### PR TITLE
feat : [#33] 내역 탭 UI 정리

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -40,12 +40,17 @@ select {
 }
 
 .ledger-top {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
   gap: 20px;
   align-items: center;
   padding: 16px 18px;
   border-bottom: 1px solid #2a3140;
+}
+
+.title-wrap {
+  min-width: 0;
+  justify-self: start;
 }
 
 .title-wrap .title {
@@ -64,6 +69,7 @@ select {
   display: flex;
   align-items: center;
   gap: 8px;
+  justify-self: center;
 }
 
 .month-chip {
@@ -110,9 +116,8 @@ select {
 }
 
 .filters {
-  display: grid;
-  grid-template-columns: repeat(7, minmax(110px, 1fr));
-  gap: 10px;
+  display: flex;
+  justify-content: flex-end;
   padding: 12px 16px;
   border-bottom: 1px solid #2a3140;
 }
@@ -135,7 +140,7 @@ select {
 }
 
 .filters .search {
-  grid-column: span 2;
+  width: min(420px, 100%);
 }
 
 .summary-cards {
@@ -702,12 +707,8 @@ select {
 }
 
 @media (max-width: 1024px) {
-  .filters {
-    grid-template-columns: repeat(3, minmax(120px, 1fr));
-  }
-
   .filters .search {
-    grid-column: span 3;
+    width: min(360px, 100%);
   }
 }
 
@@ -748,8 +749,20 @@ select {
   }
 
   .ledger-top {
-    flex-direction: column;
-    align-items: flex-start;
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+
+  .month-controls {
+    justify-self: center;
+  }
+
+  .filters {
+    padding: 10px 8px;
+  }
+
+  .filters .search {
+    width: 100%;
   }
 
   .summary-cards {

--- a/src/views/LedgerDesk.vue
+++ b/src/views/LedgerDesk.vue
@@ -11,80 +11,14 @@
           <button class="icon-btn" type="button" @click="ledger.moveMonth(-1)">&#60;</button>
           <div class="month-chip">{{ monthLabel }}</div>
           <button class="icon-btn" type="button" @click="ledger.moveMonth(1)">&#62;</button>
-          <button class="plain-btn" type="button" @click="ledger.focusCurrentMonth">이번 달</button>
         </div>
       </header>
 
       <section class="filters">
-        <label>
-          기간
-          <select v-model="ledger.state.period">
-            <option value="day">일별</option>
-            <option value="week">주간</option>
-            <option value="month">월별</option>
-            <option value="custom">기간별</option>
-          </select>
-        </label>
-        <label v-if="ledger.state.period === 'custom'">
-          시작일
-          <input v-model="ledger.state.customFrom" type="date" />
-        </label>
-        <label v-if="ledger.state.period === 'custom'">
-          종료일
-          <input v-model="ledger.state.customTo" type="date" />
-        </label>
-        <label>
-          분류
-          <select v-model="ledger.state.type">
-            <option value="all">전체</option>
-            <option value="income">수입</option>
-            <option value="expense">지출</option>
-          </select>
-        </label>
-        <label>
-          카테고리
-          <select v-model="ledger.state.category">
-            <option value="all">전체</option>
-            <option v-for="category in ledger.categoryOptions" :key="category" :value="category">
-              {{ category }}
-            </option>
-          </select>
-        </label>
-        <label>
-          자산
-          <select v-model="ledger.state.asset">
-            <option value="all">전체</option>
-            <option v-for="asset in ledger.assetOptions" :key="asset" :value="asset">
-              {{ asset }}
-            </option>
-          </select>
-        </label>
         <label class="search">
           검색
           <input v-model="ledger.state.search" type="search" placeholder="메모/분류/자산" />
         </label>
-        <button class="plain-btn" type="button" @click="ledger.fetchTransactions">새로고침</button>
-      </section>
-
-      <section class="summary-cards">
-        <article class="metric">
-          <p>전체 ({{ ledger.filteredTransactions.length }})</p>
-          <strong>{{ formatCurrency(ledger.summary.total) }}</strong>
-        </article>
-        <article class="metric">
-          <p>수입</p>
-          <strong class="income">{{ formatCurrency(ledger.summary.income) }}</strong>
-        </article>
-        <article class="metric">
-          <p>지출</p>
-          <strong class="expense">{{ formatCurrency(ledger.summary.expense) }}</strong>
-        </article>
-        <article class="metric">
-          <p>여유</p>
-          <strong :class="ledger.summary.balance >= 0 ? 'income' : 'expense'">
-            {{ formatCurrency(ledger.summary.balance) }}
-          </strong>
-        </article>
       </section>
 
       <section class="table-zone">
@@ -159,7 +93,6 @@
     </section>
 
     <div class="fab-stack">
-      <button class="fab small" type="button" @click="ledger.fetchTransactions">R</button>
       <button class="fab primary" type="button" @click="openCreate">+</button>
     </div>
 


### PR DESCRIPTION
작업 내용
- 검색을 제외한 필터 항목 제거
- 새로고침 버튼 제거
- 이번 달 버튼 제거
- 재정 요약(전체/수입/지출/여유) 영역 제거
- 검색 영역 우측 정렬 및 월 이동 컨트롤 중앙 정렬
- 우측 하단 R 플로팅 버튼 제거

변경 파일
- src/views/LedgerDesk.vue
- src/style.css

Refs #33