### PR TITLE
fix: 설정 알림 및 카테고리 동작 개선

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -24,7 +24,7 @@
           <span>프로필</span>
         </RouterLink>
         <RouterLink to="/setting" class="menu-item">
-          <span class="menu-icon">S</span>
+          <span class="menu-icon">E</span>
           <span>설정</span>
         </RouterLink>
       </nav>

--- a/src/composables/useAuth.js
+++ b/src/composables/useAuth.js
@@ -7,6 +7,7 @@ const api = axios.create({
 });
 
 const SESSION_KEY = 'kb-auth-user';
+const BUDGET_ALERT_KEY_PREFIX = 'kb-budget-alert:';
 
 const readSavedUser = () => {
   if (typeof window === 'undefined') return null;
@@ -34,6 +35,17 @@ const persistUser = (user) => {
   }
 
   window.sessionStorage.removeItem(SESSION_KEY);
+};
+
+const clearBudgetAlertFlags = () => {
+  if (typeof window === 'undefined') return;
+
+  for (let index = window.sessionStorage.length - 1; index >= 0; index -= 1) {
+    const key = window.sessionStorage.key(index);
+    if (key?.startsWith(BUDGET_ALERT_KEY_PREFIX)) {
+      window.sessionStorage.removeItem(key);
+    }
+  }
 };
 
 const normalizeUser = (user) => ({
@@ -114,6 +126,7 @@ export function useAuth() {
   };
 
   const logout = () => {
+    clearBudgetAlertFlags();
     persistUser(null);
 
     // 260409 로그아웃할 때 기본 dark로 가게 수정했습니다.

--- a/src/composables/useLedger.js
+++ b/src/composables/useLedger.js
@@ -39,6 +39,7 @@ const defaultCategories = [
 ];
 const defaultIncomeCategories = ['급여', '부수입', '환급', '용돈', '기타'];
 const PAGE_SIZE = 10;
+const OTHER_CATEGORY_NAME = '기타';
 
 const pad = (value) => String(value).padStart(2, '0');
 const formatDate = (date) => {
@@ -65,6 +66,22 @@ const getSignedAmount = (item) => {
   const amount = Number(item.amount || 0);
   return item.type === 'income' ? amount : -amount;
 };
+
+const compareCategoryNames = (left, right) => {
+  const leftName = String(left || OTHER_CATEGORY_NAME);
+  const rightName = String(right || OTHER_CATEGORY_NAME);
+  const leftIsOther = leftName === OTHER_CATEGORY_NAME;
+  const rightIsOther = rightName === OTHER_CATEGORY_NAME;
+
+  if (leftIsOther !== rightIsOther) {
+    return leftIsOther ? 1 : -1;
+  }
+
+  return leftName.localeCompare(rightName, 'ko');
+};
+
+const sortCategoriesWithOtherLast = (items) =>
+  [...items].sort((left, right) => compareCategoryNames(left.name, right.name));
 
 export function useLedger() {
   const auth = useAuth();
@@ -106,7 +123,7 @@ export function useLedger() {
         let compare = 0;
         if (state.sortBy === 'date') compare = a.date.localeCompare(b.date);
         else if (state.sortBy === 'category')
-          compare = a.category.localeCompare(b.category, 'ko');
+          compare = compareCategoryNames(a.category, b.category);
         else if (state.sortBy === 'amount')
           compare = getSignedAmount(a) - getSignedAmount(b);
 
@@ -305,7 +322,7 @@ export function useLedger() {
 
   const fetchCategories = async () => {
     const response = await api.get('/categories');
-    categories.value = response.data;
+    categories.value = sortCategoriesWithOtherLast(response.data);
   };
 
   const getEmojiByName = (name) => {
@@ -335,7 +352,10 @@ export function useLedger() {
         id: `cat-${Date.now()}`,
       });
 
-      categories.value.push(response.data);
+      categories.value = sortCategoriesWithOtherLast([
+        ...categories.value,
+        response.data,
+      ]);
       return response.data;
     } catch (error) {
       console.error('카테고리 추가 실패:', error);
@@ -345,9 +365,37 @@ export function useLedger() {
 
   const removeCategory = async (id) => {
     try {
+      const userId = requireUserId();
+      const targetCategory = categories.value.find((cat) => cat.id === id);
+
+      if (!targetCategory) {
+        throw new Error('삭제할 카테고리를 찾을 수 없습니다.');
+      }
+
+      const [transactionResponse, regularResponse] = await Promise.all([
+        api.get('/transactions', {
+          params: {
+            userId,
+            category: targetCategory.name,
+          },
+        }),
+        api.get('/regulars', {
+          params: {
+            userId,
+            category: targetCategory.name,
+          },
+        }),
+      ]);
+
+      if (transactionResponse.data.length > 0 || regularResponse.data.length > 0) {
+        throw new Error('내역 또는 정기결제에서 사용 중인 카테고리는 삭제할 수 없습니다.');
+      }
+
       await api.delete(`/categories/${id}`);
 
-      categories.value = categories.value.filter((cat) => cat.id !== id);
+      categories.value = sortCategoriesWithOtherLast(
+        categories.value.filter((cat) => cat.id !== id),
+      );
     } catch (error) {
       console.error('카테고리 삭제 실패:', error);
       throw error;

--- a/src/composables/useSettings.js
+++ b/src/composables/useSettings.js
@@ -3,6 +3,7 @@ import axios from 'axios';
 
 // 전역 상태로 관리하여 다른 컴포넌트와 데이터 동기화
 const budget = ref(0);
+const budgetAlertEnabled = ref(false);
 
 const API_URL = 'http://localhost:3001/users';
 
@@ -12,6 +13,10 @@ export function useSettings() {
     try {
       const response = await axios.get(`${API_URL}/${userId}`);
       budget.value = response.data.budget || 0;
+      budgetAlertEnabled.value =
+        typeof response.data.budgetAlertEnabled === 'boolean'
+          ? response.data.budgetAlertEnabled
+          : Number(response.data.budget || 0) > 0;
     } catch (error) {
       console.error('예산 로드 실패:', error);
     }
@@ -23,16 +28,31 @@ export function useSettings() {
       await axios.patch(`${API_URL}/${userId}`, {
         budget: Number(newBudget),
       });
-      budget.value = newBudget;
+      budget.value = Number(newBudget);
     } catch (error) {
       console.error('예산 저장 실패:', error);
       throw error;
     }
   };
 
+  const updateBudgetAlertEnabled = async (userId, enabled) => {
+    if (!userId) return;
+    try {
+      await axios.patch(`${API_URL}/${userId}`, {
+        budgetAlertEnabled: Boolean(enabled),
+      });
+      budgetAlertEnabled.value = Boolean(enabled);
+    } catch (error) {
+      console.error('예산 알림 설정 저장 실패:', error);
+      throw error;
+    }
+  };
+
   return {
     budget,
+    budgetAlertEnabled,
     fetchUserBudget,
     updateUserBudget,
+    updateBudgetAlertEnabled,
   };
 }

--- a/src/views/DashboardDesk.vue
+++ b/src/views/DashboardDesk.vue
@@ -88,7 +88,11 @@ import { useAuth } from '../composables/useAuth';
 
 const ledger = useLedger();
 const auth = useAuth();
-const { budget, fetchUserBudget } = useSettings();
+const { budget, budgetAlertEnabled, fetchUserBudget } = useSettings();
+const budgetAlertKey = computed(() => {
+  const userId = auth.state.currentUser?.id;
+  return userId ? `kb-budget-alert:${userId}` : '';
+});
 
 const normalizeDate = (value) => {
   if (!value) return '';
@@ -151,7 +155,14 @@ const dashboardStatus = computed(() => {
 });
 
 const checkBudgetExceeded = () => {
-  if (budget.value > 0 && currentMonthExpense.value > budget.value) {
+  if (
+    budgetAlertEnabled.value &&
+    currentMonthExpense.value > budget.value &&
+    typeof window !== 'undefined' &&
+    budgetAlertKey.value &&
+    !window.sessionStorage.getItem(budgetAlertKey.value)
+  ) {
+    window.sessionStorage.setItem(budgetAlertKey.value, 'shown');
     setTimeout(() => {
       alert(
         `⚠️ 예산 초과 알림\n\n목표 예산(${budget.value.toLocaleString()}원)보다 ` +

--- a/src/views/SettingDesk.vue
+++ b/src/views/SettingDesk.vue
@@ -12,13 +12,34 @@
       </div>
 
       <div v-if="activeMenu === 'budget'" class="item-content">
-        <div class="flex-row">
-          <input
-            type="number"
-            v-model="budget"
-            placeholder="월 목표 예산 입력"
-          />
-          <button @click="handleSaveBudget" class="solid-btn">저장</button>
+        <div class="form-container budget-form">
+          <div class="field">
+            <label>총 지출액</label>
+            <input
+              type="number"
+              min="0"
+              v-model.number="budgetDraft"
+              placeholder="0"
+              @change="handleBudgetChange"
+            />
+          </div>
+
+          <div class="budget-actions">
+            <button
+              type="button"
+              class="budget-switch"
+              :class="{ active: isBudgetAlertEnabled }"
+              :aria-pressed="isBudgetAlertEnabled"
+              @click="handleToggleBudgetAlert"
+            >
+              <span class="budget-switch-track">
+                <span class="budget-switch-thumb"></span>
+              </span>
+              <span class="budget-switch-label">
+                {{ isBudgetAlertEnabled ? 'ON' : 'OFF' }}
+              </span>
+            </button>
+          </div>
         </div>
       </div>
     </section>
@@ -176,26 +197,59 @@
 </template>
 
 <script setup>
-import { ref, onMounted, computed, onUnmounted } from 'vue';
+import { ref, onMounted, computed, onUnmounted, watch } from 'vue';
 import { useLedger } from '../composables/useLedger';
 import { useSettings } from '../composables/useSettings';
 import { useAuth } from '../composables/useAuth';
 
 const ledger = useLedger();
 const auth = useAuth();
-const { budget, fetchUserBudget, updateUserBudget } = useSettings();
+const {
+  budget,
+  budgetAlertEnabled,
+  fetchUserBudget,
+  updateUserBudget,
+  updateBudgetAlertEnabled,
+} = useSettings();
 
 const activeMenu = ref(null);
 const currentUserId = computed(() => auth.state.currentUser?.id);
+const budgetDraft = ref(0);
+const isBudgetAlertEnabled = computed(() => budgetAlertEnabled.value);
 
 const toggleMenu = (menuName) => {
   activeMenu.value = activeMenu.value === menuName ? null : menuName;
 };
 
-const handleSaveBudget = async () => {
+const clearBudgetAlertSession = () => {
+  if (typeof window === 'undefined' || !currentUserId.value) return;
+  window.sessionStorage.removeItem(`kb-budget-alert:${currentUserId.value}`);
+};
+
+const handleBudgetChange = async () => {
+  if (!currentUserId.value) return;
+
   try {
-    await updateUserBudget(currentUserId.value, budget.value);
-    alert('목표 예산이 저장되었습니다!');
+    await updateUserBudget(
+      currentUserId.value,
+      Math.max(0, Number(budgetDraft.value) || 0),
+    );
+    clearBudgetAlertSession();
+  } catch (error) {
+    alert('저장에 실패했습니다.');
+  }
+};
+
+const handleToggleBudgetAlert = async () => {
+  if (!currentUserId.value) return;
+
+  try {
+    await updateUserBudget(
+      currentUserId.value,
+      Math.max(0, Number(budgetDraft.value) || 0),
+    );
+    await updateBudgetAlertEnabled(currentUserId.value, !isBudgetAlertEnabled.value);
+    clearBudgetAlertSession();
   } catch (error) {
     alert('저장에 실패했습니다.');
   }
@@ -301,7 +355,7 @@ const handleDeleteCategory = async (id, name) => {
     try {
       await ledger.removeCategory(id);
     } catch (error) {
-      alert('삭제 실패');
+      alert(error.message || '삭제 실패');
     }
   }
 };
@@ -318,6 +372,14 @@ const setTheme = (theme) => {
   else document.body.classList.remove('theme-kb');
   localStorage.setItem('app-theme', theme);
 };
+
+watch(
+  budget,
+  (value) => {
+    budgetDraft.value = Number(value) || 0;
+  },
+  { immediate: true },
+);
 
 onMounted(async () => {
   await ledger.fetchCategories();
@@ -521,6 +583,61 @@ select:focus {
 .full-width {
   width: 100%;
   margin-top: 10px;
+}
+
+.budget-form {
+  gap: 16px;
+}
+
+.budget-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.budget-switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-main);
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.budget-switch-track {
+  position: relative;
+  width: 52px;
+  height: 30px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.35);
+  transition: background 0.2s ease;
+}
+
+.budget-switch-thumb {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: #ffffff;
+  box-shadow: 0 2px 8px rgba(15, 23, 42, 0.2);
+  transition: transform 0.2s ease;
+}
+
+.budget-switch.active .budget-switch-track {
+  background: var(--point-gradient);
+}
+
+.budget-switch.active .budget-switch-thumb {
+  transform: translateX(22px);
+}
+
+.budget-switch-label {
+  min-width: 34px;
+  text-align: right;
 }
 
 .category-tags {

--- a/src/views/StatsDesk.vue
+++ b/src/views/StatsDesk.vue
@@ -176,6 +176,19 @@ const pieColors = [
   '#f472b6'
 ]
 
+const compareCategoryNames = (left, right) => {
+  const leftName = String(left || '기타')
+  const rightName = String(right || '기타')
+  const leftIsOther = leftName === '기타'
+  const rightIsOther = rightName === '기타'
+
+  if (leftIsOther !== rightIsOther) {
+    return leftIsOther ? 1 : -1
+  }
+
+  return leftName.localeCompare(rightName, 'ko')
+}
+
 const allTransactions = computed(() => {
   if (Array.isArray(ledger.transactions)) return ledger.transactions
   if (Array.isArray(ledger.state?.transactions)) return ledger.state.transactions
@@ -255,7 +268,13 @@ const categoryBreakdown = computed(() => {
   const totalExpense = monthSummary.value.expense || 0
 
   return Object.values(grouped)
-    .sort((a, b) => b.amount - a.amount)
+    .sort((a, b) => {
+      if (a.category === '기타' || b.category === '기타') {
+        return compareCategoryNames(a.category, b.category)
+      }
+
+      return b.amount - a.amount
+    })
     .map((item, index) => ({
       ...item,
       color: pieColors[index % pieColors.length],


### PR DESCRIPTION
- 설정 메뉴 아이콘을 `S`에서 `E`로 변경
- 지출액 초과 알림 버튼을 ON/OFF 토글 스위치로 변경
- 신규 계정은 `0원`, `OFF` 상태로 시작하도록 정리
- 예산 입력값은 로그아웃 후에도 유지되도록 저장 구조 개선
- OFF 상태여도 마지막 입력값은 유지되도록 수정
- 로그인 중 대시보드 알림은 한 번만 뜨도록 수정
- 예산 금액을 변경하면 변경된 값 기준으로 알림이 다시 한 번 뜨도록 수정
- 카테고리 `기타`가 항상 마지막에 오도록 정렬
- 위 정렬 규칙을 설정, 내역, 통계 화면에 반영
- 거래 내역이나 정기결제에서 사용 중인 카테고리는 삭제되지 않도록 제한
